### PR TITLE
Remove VTHO Contract SubAccount From Block Transaction Parser

### DIFF
--- a/src/common/transConverter.ts
+++ b/src/common/transConverter.ts
@@ -136,10 +136,7 @@ export class TransactionConverter {
             type:OperationType.FeeDelegation,
             status:OperationStatus.None,
             account:{
-                address:rece.gasPayer,
-                sub_account:{
-                    address:VTHOCurrency.metadata.contractAddress
-                }
+                address:rece.gasPayer
             },
             amount:{
                 value:(BigInt(rece.paid) * BigInt(-1)).toString(10),
@@ -157,10 +154,7 @@ export class TransactionConverter {
             type:OperationType.Fee,
             status:OperationStatus.None,
             account:{
-                address:rece.gasPayer,
-                sub_account:{
-                    address:VTHOCurrency.metadata.contractAddress
-                }
+                address:rece.gasPayer
             },
             amount:{
                 value:(BigInt(rece.paid) * BigInt(-1)).toString(10),


### PR DESCRIPTION
Removing VTHO sub-account in this PR from block and transaction parser.

sub-account contains VTHO contract address. Since VTHO is a native token and can be represented by currency in amount, we may not need to provide a subaccount here explicitly.

