### PR TITLE
fix network/options error containing details and description keys

### DIFF
--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -1,7 +1,7 @@
 import { RosettaError } from "./types/error";
 
 export function getError(code:number,description?:string,details?:any):RosettaError {
-    let error = Errors.get(code) || Errors.get(500)!;
+    let error = Object.assign({},Errors.get(code) || Errors.get(500)!);
     error.description = error.description || description,
     error.details = error.details || details;
     return error;


### PR DESCRIPTION

Bug: `/network/options`  returns the description and details key in error objects if we encounter any rosetta error in any previous API call.

Fix:
On getting a rosetta error, We need to pass the error object "by copy" instead of "pass by reference".
