### PR TITLE
update runner to ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN git clone https://github.com/vechain/thor.git /go/thor
 RUN git checkout ${THOR_VERSION}
 RUN make all
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 WORKDIR /data
 WORKDIR /usr/src/app


### PR DESCRIPTION
To eliminate error 'version `GLIBC_2.33' not found'.