### PR TITLE
Include the nonce when calling metadata

### DIFF
--- a/src/controllers/construction.ts
+++ b/src/controllers/construction.ts
@@ -799,3 +799,4 @@ export class Construction extends Router {
         kind: [...this.unsignedRosettaTransactionRlp.profile.kind as Array<any>, { name: 'signature', kind: new RLP.BufferKind() }],
     });
 }
+

--- a/src/controllers/construction.ts
+++ b/src/controllers/construction.ts
@@ -799,4 +799,3 @@ export class Construction extends Router {
         kind: [...this.unsignedRosettaTransactionRlp.profile.kind as Array<any>, { name: 'signature', kind: new RLP.BufferKind() }],
     });
 }
-

--- a/src/controllers/construction.ts
+++ b/src/controllers/construction.ts
@@ -656,7 +656,7 @@ export class Construction extends Router {
         const schema = Joi.object({
             metadata:Joi.object({
                 blockRef:Joi.string().lowercase().length(18).regex(/^(-0x|0x)?[0-9a-f]*$/).required(),
-                nonce:Joi.string().lowercase().length(18).regex(/^(-0x|0x)?[0-9a-f]*$/).optional(),
+                nonce:Joi.string().lowercase().length(18).regex(/^(0x)?[0-9a-f]+$/).optional(),
                 chainTag:Joi.number().valid(this.env.config.chainTag).required(),
                 gas:Joi.number().min(21000).required(),
                 fee_delagator_account:Joi.string().lowercase().length(42).regex(/^(-0x|0x)?[0-9a-f]*$/)

--- a/src/controllers/construction.ts
+++ b/src/controllers/construction.ts
@@ -656,7 +656,7 @@ export class Construction extends Router {
         const schema = Joi.object({
             metadata:Joi.object({
                 blockRef:Joi.string().lowercase().length(18).regex(/^(-0x|0x)?[0-9a-f]*$/).required(),
-                nonce:Joi.string().lowercase().length(18).regex(/0x?[0-9a-f]*$/).optional(),
+                nonce:Joi.string().lowercase().length(18).regex(/^(-0x|0x)?[0-9a-f]*$/).optional(),
                 chainTag:Joi.number().valid(this.env.config.chainTag).required(),
                 gas:Joi.number().min(21000).required(),
                 fee_delagator_account:Joi.string().lowercase().length(42).regex(/^(-0x|0x)?[0-9a-f]*$/)

--- a/src/controllers/construction.ts
+++ b/src/controllers/construction.ts
@@ -149,7 +149,8 @@ export class Construction extends Router {
                     metadata:{
                         blockRef:blockRef,
                         chainTag:chainTag,
-                        gas:gas
+                        gas:gas,
+                        nonce:'0x' + randomBytes(8).toString('hex')
                     },
                     suggested_fee:[{
                         value:(fee * BigInt(-1)).toString(10),

--- a/src/controllers/construction.ts
+++ b/src/controllers/construction.ts
@@ -214,7 +214,7 @@ export class Construction extends Router {
                 expiration:this.env.config.expiration as number,
                 clauses:clauses,
                 gas:ctx.request.body.metadata.gas,
-                nonce:'0x' + randomBytes(8).toString('hex'),
+                nonce: ctx.request.body.metadata.nonce || '0x' + randomBytes(8).toString('hex'),
                 gasPriceCoef:0,
                 dependsOn:null
             }
@@ -656,6 +656,7 @@ export class Construction extends Router {
         const schema = Joi.object({
             metadata:Joi.object({
                 blockRef:Joi.string().lowercase().length(18).regex(/^(-0x|0x)?[0-9a-f]*$/).required(),
+                nonce:Joi.string().lowercase().length(18).regex(/0x?[0-9a-f]*$/).optional(),
                 chainTag:Joi.number().valid(this.env.config.chainTag).required(),
                 gas:Joi.number().min(21000).required(),
                 fee_delagator_account:Joi.string().lowercase().length(42).regex(/^(-0x|0x)?[0-9a-f]*$/)


### PR DESCRIPTION
Following this PR : https://github.com/vechain/rosetta/pull/34 - we need the nonce to be present when calling `metadata`